### PR TITLE
IIS removal + netsh ssl cert binding to Broker Service

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,10 @@
 # xd7mastercontroller #
 
-This modules install a fully working Citrix 7.x Delivery Controller, including Citrix site creation and administrator rights setup.
+This modules install an enterprise production grade Citrix 7.x Delivery Controller, including Citrix site creation and administrator rights setup.
 
 The following options are available for a production-grade installation :
 - Fault tolerance : AlwaysOn database membership activation for Citrix databases created by the package
-- Sécurity : SSL configuration to secure communications with the Citrix XML service
+- Sécurity : SSL configuration to secure communications with the Citrix XML Broker Service
 
 ## Integration informations
 The Citrix databases will be installed in the default MSSQLSERVER SQL Server instance. This module does not provide the capability to install the databases in another SQL intance.

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,59 +1,57 @@
 class xd7mastercontroller::install inherits xd7mastercontroller {
   
-   reboot { 'after_run':
-	  apply => immediately,
-    when => refreshed
-  } 
-  
-  dsc_xcredssp{ 'Server':
-      dsc_ensure => 'Present',
-      dsc_role => 'Server',
-      notify => Reboot['after_run']
-  }
-
-  dsc_xcredssp{ 'Client':
-      dsc_ensure => 'Present',
-      dsc_role => 'Client',
-      dsc_delegatecomputers => '*'
-  }
-  
-  dsc_windowsfeature{'iis':
-	  dsc_ensure => 'Present',
-	  dsc_name   => 'Web-Server',
-	}
-  
-  dsc_windowsfeature{'Web-Scripting-Tools':
-	  dsc_ensure => 'Present',
-	  dsc_name   => 'Web-Scripting-Tools',
+	reboot { 'after_run':
+	 apply => immediately,
+	 when => refreshed
+	} 
+	
+	dsc_xcredssp{ 'Server':
+	 dsc_ensure => 'Present',
+	 dsc_role => 'Server',
+	 notify => Reboot['after_run']
 	}
 	
-  dsc_windowsfeature{'Web-Mgmt-Console':
-	  dsc_ensure => 'Present',
-	  dsc_name   => 'Web-Mgmt-Console',
-  }
+	dsc_xcredssp{ 'Client':
+	 dsc_ensure => 'Present',
+	 dsc_role => 'Client',
+	 dsc_delegatecomputers => '*'
+	}
+	
+	#Ensure IIS is not installed on the system to avoid conflicts with Broker Service
+	dsc_windowsfeature{'iis':
+	 dsc_ensure => 'Absent',
+	 dsc_name   => 'Web-Server',
+	}
   
-  dsc_xd7features { 'XD7DeliveryController':
-	  dsc_issingleinstance => 'Yes',
-	  dsc_role => [Studio, Controller],
-	  dsc_sourcepath => $sourcepath,
-	  dsc_ensure => 'present',
-	  require => Dsc_windowsfeature['iis'],
-	  notify => Reboot['after_run']
-  }
+  #Install Delivery Controller
+	dsc_xd7features { 'XD7DeliveryController':
+	 dsc_issingleinstance => 'Yes',
+	 dsc_role => [Studio, Controller],
+	 dsc_sourcepath => $sourcepath,
+	 dsc_ensure => 'present',
+	 require => Dsc_windowsfeature['iis'],
+	 notify => Reboot['after_run']
+	}
   
-  #SQLSERVER powershell module deployment.
-  #Required for database high awailability setup (always on citrix databases membership)
-  file{ "C:\\Program Files\\WindowsPowerShell\\Modules\\sqlserver_powershell_21.0.17199.zip":
-      source => 'puppet:///modules/xd7mastercontroller/sqlserver_powershell_21.0.17199.zip',
-      source_permissions => ignore,
-  }
+	#Download and install SQLSERVER powershell module. Required for database high availability setup (always on citrix databases membership)
+	file{ "C:\\Program Files\\WindowsPowerShell\\Modules\\sqlserver_powershell_21.0.17199.zip":
+	 source => 'puppet:///modules/xd7mastercontroller/sqlserver_powershell_21.0.17199.zip',
+	 source_permissions => ignore,
+	}
   
-  #Function provided by the reidmv-unzip
-  unzip{'UnzipSqlserverModule':
-	  source  => 'C:\\Program Files\WindowsPowerShell\Modules\sqlserver_powershell_21.0.17199.zip',
-	  destination => 'C:\\Program Files\WindowsPowerShell\Modules',
-	  creates => 'C:\\Program Files\WindowsPowerShell\Modules\SqlServer',
-	  require => File["C:\\Program Files\\WindowsPowerShell\\Modules\\sqlserver_powershell_21.0.17199.zip"]
-  }
+  #dsc_xarchive{'UnzipSqlserverModule':
+	#  dsc_path  => 'C:\Program Files\WindowsPowerShell\Modules\sqlserver_powershell_21.0.17199.zip',
+	#  dsc_destination => 'C:\Program Files\WindowsPowerShell\Modules',
+	#  dsc_force => true,
+	#  require => File["C:\\Program Files\\WindowsPowerShell\\Modules\\sqlserver_powershell_21.0.17199.zip"]
+  #}
+  
+	#Unzip function provided by the reidmv-unzip
+	unzip{'UnzipSqlserverModule':
+	 source  => 'C:\\Program Files\WindowsPowerShell\Modules\sqlserver_powershell_21.0.17199.zip',
+	 destination => 'C:\\Program Files\WindowsPowerShell\Modules',
+	 creates => 'C:\\Program Files\WindowsPowerShell\Modules\SqlServer',
+	 require => File["C:\\Program Files\\WindowsPowerShell\\Modules\\sqlserver_powershell_21.0.17199.zip"]
+	}
 
 }

--- a/manifests/sslconfig.pp
+++ b/manifests/sslconfig.pp
@@ -1,37 +1,48 @@
 class xd7mastercontroller::sslconfig inherits xd7mastercontroller {
   if $https {
-    dsc_file{ 'SSLCert':
-      dsc_sourcepath => $sslCertificateSourcePath,
-      dsc_destinationpath => 'c:\SSL\cert.pfx',
-      dsc_type => 'File'
-    }
-    
-    dsc_xpfximport{ 'ImportSSLCert':
-      dsc_thumbprint => $sslCertificateThumbprint,
-      dsc_path => 'c:\SSL\cert.pfx',
-      dsc_location => 'LocalMachine',
-      dsc_store => 'WebHosting',
-      dsc_credential => {'user' => 'cert', 'password' => $sslCertificatePassword },
-      require => Dsc_file['SSLCert']
-    }
+		reboot { 'after_sslconfig':
+		  apply => finished,
+		  when => refreshed
+		} 
 
-    dsc_xwebsite{ 'DefaultWebSite': 
-      dsc_name => 'Default Web Site',
-      dsc_physicalpath => 'C:\inetpub\wwwroot',
-      dsc_bindinginfo => [
-        { protocol => 'HTTPS', port => '443', certificatethumbprint => $sslCertificateThumbprint, certificatestorename => 'WebHosting' },
-        #{ protocol => 'HTTPS', certificatethumbprint => 'A4D8B8E3B1B6910CB54C3B6CDFD6478914327850' },
-        #{ protocol => 'HTTPS', certificatestorename => 'My'; },
-        #{ protocol => 'HTTP', port => '80'}
-        ],
-      require => Dsc_xpfximport['ImportSSLCert']
+		#Download SSL certificate
+		dsc_file{ 'SSLCert':
+		  dsc_sourcepath => $sslCertificateSourcePath,
+		  dsc_destinationpath => 'c:\SSL\cert.pfx',
+		  dsc_type => 'File'
+		}->
+
+		#Load SSL certificate in Local Computer personal certificate store
+		dsc_xpfximport{ 'ImportSSLCert':
+		  dsc_thumbprint => $sslCertificateThumbprint,
+		  dsc_path => 'c:\SSL\cert.pfx',
+		  dsc_location => 'LocalMachine',
+		  dsc_store => 'My',
+		  dsc_credential => {'user' => 'cert', 'password' => $sslCertificatePassword },
+		  require => Dsc_file['SSLCert']
+		}->
+
+		#Map SSL certificate to Citrix Broker Service using netsh method
+		#netsh http add sslcert ipport=0.0.0.0:443 certhash=<Certificate Hash Number> appid={<Citrix Broker Service GUID>}
+		dsc_script{ 'CitrixBrokerServiceSSL':
+		  dsc_getscript => 'Return @{ Result = [string]$(netsh http show sslcert) }',
+		  dsc_testscript => 'If ((netsh http show sslcert | Select-String  "Application ID") -like "*Application*") {
+                  Return $true
+                } Else {
+                   Return $false
+                }',
+			dsc_setscript => "\$brokerservice = get-wmiobject -class Win32_Product | Where-Object {\$_.name -Like \"*Broker Service*\"}
+			   \$guid = \$brokerservice.IdentifyingNumber
+			   netsh http add sslcert ipport=0.0.0.0:443 certhash=${$sslCertificateThumbprint} appid=\$guid",
+			notify => Reboot['after_sslconfig']
     }
-    
-	registry_value { 'HKLM\SOFTWARE\Citrix\DesktopServer\XmlServicesSslPort':
-	  ensure => present,
-	  type   => 'dword',
-	  data   => '443',
-	  require => Dsc_xd7features ['XD7DeliveryController']
-	}
+  
+		#Make sure Citrix XML Service SSL port is 443
+		registry_value { 'HKLM\SOFTWARE\Citrix\DesktopServer\XmlServicesSslPort':
+		  ensure => present,
+		  type   => 'dword',
+		  data   => '443',
+		  require => Dsc_xd7features ['XD7DeliveryController']
+		}
   }   
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "author": "citrixdeployment",
+  "author": "virtualdesktopdevops",
   "dependencies": [
 	{ 
 		"name": "reidmv/unzip", 
@@ -15,7 +15,7 @@
 	}
   ],
   "license": "Apache-2.0",
-  "name": "citrixdeployment-xd7mastercontroller",
+  "name": "virtualdesktopdevops-xd7mastercontroller",
   "operatingsystem_support": [
     {
       "operatingsystem": "windows",
@@ -25,15 +25,15 @@
       ]
     }
   ],
-  "project_page": "https://www.citrixdeployment.com",
+  "project_page": "http://www.virtualdesktopdevops.com",
   "requirements": [
   	{
       "name": "puppet",
       "version_requirement": ">= 3.8.0 < 6.0.0"
     }
   ],
-  "source": "https://www.citrixdeployment.com",
-  "summary": "Xendesktop 7.x Delivery Controller & site creation",
+  "source": "http://www.virtualdesktopdevops.com/",
+  "summary": "Xendesktop 7.x Delivery Controller installation & site creation",
   "tags": [
     "powershell",
     "dsc",


### PR DESCRIPTION
Ensures IIS is absent to avoid conflicts with Citrix Broker Service
Change SSL certificate store from 'webhosting' du 'My'
Map SSL certificate to Citrix Broker Service using netsh method